### PR TITLE
docs(infra): document GitHub as decision history channel — closes #4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ The full design is in `docs/specs/2026-03-27-session-sentinel-design.md`. Read i
 - **Issues** are the source of truth. Every change traces to an issue.
 - **Planning:** GitHub Projects (Kanban view)
 - **CI/CD:** GitHub Actions
+- **GitHub is the conversation channel for history.** Everything recorded there (PRs, issues, comments) is a taken decision. Decisions not documented on GitHub are lost between sessions.
 
 ### Branch strategy
 
@@ -90,6 +91,8 @@ Rules:
 - PR must reference the issue it closes: `closes #N` in the body
 - Merge strategy: **squash merge** to keep main history clean
 - After merge, the Kanban card moves to Done automatically
+- **Comment on PRs** to record decisions, risks, and context — this becomes the historical record
+- Create follow-up issues when identifying future work, risks, or pending decisions during PR review
 
 ### Issue discipline
 


### PR DESCRIPTION
## Summary

- Explicitar no CLAUDE.md que GitHub (PRs, issues, comentarios) e o canal canonico de registro de decisoes
- Adicionar guideline de comentarios em PRs e criacao de issues de follow-up

## Changes

**Source of Truth section:**
> GitHub is the conversation channel for history. Everything recorded there (PRs, issues, comments) is a taken decision. Decisions not documented on GitHub are lost between sessions.

**Pull Requests section:**
> Comment on PRs to record decisions, risks, and context — this becomes the historical record.
> Create follow-up issues when identifying future work, risks, or pending decisions during PR review.

## Why

Feedback do operador durante Sprint 0: o padrao de branch → PR → comentarios → issues ja era o esperado, mas nao estava documentado explicitamente. Agentes e contribuidores precisam seguir esse padrao para manter rastreabilidade.

## Test plan

- [x] CLAUDE.md updated with two additions
- [x] No other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)