### PR TITLE
fix(dashboard): correct DB path resolution — closes #11

### DIFF
--- a/dashboard/src/lib/db.ts
+++ b/dashboard/src/lib/db.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3';
 import path from 'node:path';
 
-const DB_PATH = path.resolve(import.meta.dirname, '../../sentinel-dev.db');
+const DB_PATH = path.resolve(import.meta.dirname, '../../../sentinel-dev.db');
 
 let db: Database.Database | null = null;
 


### PR DESCRIPTION
## Summary

- `import.meta.dirname` in `dashboard/src/lib/db.ts` resolves to `dashboard/src/lib/`
- `../../sentinel-dev.db` landed in `dashboard/` instead of the project root
- Fix: `../../../sentinel-dev.db` resolves correctly to project root

## Test plan

- [x] `npx tsx sandbox/seed.ts` then `cd dashboard && npm run dev` — dashboard loads without 500 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)