### PR TITLE
docs(sprint3): write Sprint 3 implementation plan — closes #17

### DIFF
--- a/docs/plans/2026-03-28-sprint3-housekeeping-dashboard-deploy.md
+++ b/docs/plans/2026-03-28-sprint3-housekeeping-dashboard-deploy.md
@@ -702,9 +702,9 @@ git commit -m "feat(infra): integrate Housekeeper — skip managed sessions in M
 - Modify: `dashboard/src/routes/sessions/[id]/+page.server.ts`
 - Test: `tests/integration/api.test.ts`
 
-- [ ] **Step 1: Write failing test for notifications in session detail**
+- [ ] **Step 1: Write failing tests for notifications in session detail**
 
-Add a test in `tests/integration/api.test.ts` within the session detail describe block:
+Add tests in `tests/integration/api.test.ts` within the session detail describe block:
 
 ```typescript
   it('GET /sessions/:id includes notifications array', async () => {
@@ -745,6 +745,66 @@ Add a test in `tests/integration/api.test.ts` within the session detail describe
     expect(body.notifications).toBeDefined();
     expect(body.notifications).toHaveLength(1);
     expect(body.notifications[0].trigger).toBe('waiting');
+  });
+
+  it('GET /sessions/:id returns empty notifications array when none exist', async () => {
+    const session = queries.upsertSession({
+      claude_session_id: 'cs-detail-no-notif',
+      jsonl_path: '/tmp/no-notif.jsonl',
+      status: 'active',
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/sessions/${session.id}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.notifications).toBeDefined();
+    expect(body.notifications).toEqual([]);
+  });
+
+  it('GET /sessions/:id returns multiple notifications in order', async () => {
+    const session = queries.upsertSession({
+      claude_session_id: 'cs-detail-multi-notif',
+      jsonl_path: '/tmp/multi-notif.jsonl',
+      status: 'error',
+      type: 'managed',
+    });
+    queries.updateSessionOwner(session.id, 'moon');
+
+    const basePayload = {
+      sessionId: session.id, label: null, status: 'waiting',
+      project: null, gitBranch: null, pendingQuestion: null,
+      errorMessage: null, waitingSince: null,
+      apiUrl: `http://localhost:3100/sessions/${session.id}`,
+    };
+
+    queries.insertNotification({
+      session_id: session.id, channel: 'discord_owner',
+      destination: '#moon', trigger: 'waiting',
+      payload: { ...basePayload, status: 'waiting' }, delivered: true,
+    });
+    queries.insertNotification({
+      session_id: session.id, channel: 'discord_sentinel_log',
+      destination: '#sentinel-log', trigger: 'waiting',
+      payload: { ...basePayload, status: 'waiting' }, delivered: true,
+    });
+    queries.insertNotification({
+      session_id: session.id, channel: 'discord_owner',
+      destination: '#moon', trigger: 'error',
+      payload: { ...basePayload, status: 'error', errorMessage: 'crash' }, delivered: false,
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/sessions/${session.id}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.notifications).toHaveLength(3);
   });
 ```
 


### PR DESCRIPTION
## Summary

- Sprint 3 implementation plan: **Housekeeping, Dashboard Actions & Deploy**
- 6 tasks with dependency graph, TDD steps, complete code blocks, commit messages
- Same format as Sprint 2 plan (`docs/plans/2026-03-28-sprint2-manager-api.md`)

### Tasks

| # | Task | Depends on | Spec Section |
|---|------|-----------|-------------|
| 1 | Housekeeping Foundation (types, constants, terminateSession options) | — | 13 |
| 2 | Housekeeper Core (TDD — sweep logic, idle auto-kill) | 1 | 13 |
| 3 | Housekeeper Integration (Monitor skip managed, main.ts wiring) | 2 | 13 |
| 4 | Session Detail: Notifications (API + dashboard data) | — | 8 |
| 5 | Dashboard Actions (terminate button, resume cmd, notification history) | 4 | 8 |
| 6 | systemd Deploy (unit files, env, npm scripts) | 3 | 15 |

### Key architectural decisions

- **Housekeeper** lives in `src/manager/housekeeper.ts` — periodic sweep, queries managed+idle sessions, terminates via Manager after 15 min
- **Monitor adjustment** — `checkIdleSessions()` skips managed sessions in idle→ended (only Housekeeper manages lifecycle of managed sessions)
- **Dashboard actions** — direct `fetch()` to API (CORS already enabled), no proxy needed
- **Housekeeping is silent** — no notifications (`ended` ∉ `NOTIFICATION_TRIGGERS`)

### Deferred to Sprint 4

- Notification delivery validation with real `agent-notify.sh`
- E2E smoke test with real SDK `query()`
- OpenAPI spec (`GET /docs`)

closes #17

## Test plan

- [ ] Plan follows Sprint 2 format (tasks, dependency graph, TDD, complete code)
- [ ] Spec references are accurate (Sections 8, 13, 15)
- [ ] Dependency graph allows parallel execution (Tasks 1-3 independent of Task 4)
- [ ] No placeholders — all steps have complete code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)