### PR TITLE
fix(api): by_project.ended_today date filter + WebSocket event/notification broadcasts — closes #23

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -148,13 +148,14 @@ export function registerRoutes(app: FastifyInstance, manager: SessionManager | n
 
     // Group by project
     const allSessions = queries.listSessions({});
+    const today = new Date().toISOString().slice(0, 10);
     const byProject: Record<string, { active: number; waiting: number; ended_today: number }> = {};
     for (const s of allSessions) {
       const proj = s.project_name ?? 'unknown';
       if (!byProject[proj]) byProject[proj] = { active: 0, waiting: 0, ended_today: 0 };
       if (s.status === 'active') byProject[proj].active++;
       if (s.status === 'waiting') byProject[proj].waiting++;
-      if (s.status === 'ended') byProject[proj].ended_today++;
+      if (s.status === 'ended' && s.updated_at?.startsWith(today)) byProject[proj].ended_today++;
     }
 
     return {

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -9,6 +9,7 @@ import type { EventEmitter } from 'node:events';
 export interface ServerConfig {
   manager: SessionManager | null;
   monitor?: EventEmitter | null;
+  bridge?: EventEmitter | null;
   logger?: boolean;
 }
 
@@ -24,7 +25,7 @@ export function buildServer(config: ServerConfig): FastifyInstance {
   // the plugin is available when the route is defined.
   app.register(async (instance) => {
     await instance.register(websocket);
-    registerWebSocket(instance, config.monitor ?? null);
+    registerWebSocket(instance, config.monitor ?? null, config.bridge ?? null);
   });
 
   registerRoutes(app, config.manager);

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -2,34 +2,56 @@ import type { FastifyInstance } from 'fastify';
 import type { EventEmitter } from 'node:events';
 import type { WebSocket } from 'ws';
 import type { Session, SessionEvent, WsOutgoingMessage } from '../shared/types.js';
+import { eventBus } from '../shared/event-bus.js';
 
 const clients = new Set<WebSocket>();
 
-export function registerWebSocket(app: FastifyInstance, monitor: EventEmitter | null): void {
+export function registerWebSocket(
+  app: FastifyInstance,
+  monitor: EventEmitter | null,
+  bridge: EventEmitter | null,
+): void {
   app.get('/ws', { websocket: true }, (socket) => {
     clients.add(socket);
     socket.on('close', () => clients.delete(socket));
     socket.on('error', () => clients.delete(socket));
   });
 
-  if (!monitor) return;
-
-  monitor.on('session:discovered', (data: { session: Session }) => {
-    broadcast({ type: 'session_update', session: data.session });
-  });
-
-  monitor.on('session:status_changed', (data: { session: Session; from: string; to: string }) => {
-    broadcast({
-      type: 'status_change',
-      sessionId: data.session.id,
-      from: data.from,
-      to: data.to,
+  if (monitor) {
+    monitor.on('session:discovered', (data: { session: Session }) => {
+      broadcast({ type: 'session_update', session: data.session });
     });
+
+    monitor.on('session:status_changed', (data: { session: Session; from: string; to: string }) => {
+      broadcast({
+        type: 'status_change',
+        sessionId: data.session.id,
+        from: data.from,
+        to: data.to,
+      });
+    });
+
+    monitor.on('session:activity', (data: { session: Session }) => {
+      broadcast({ type: 'session_update', session: data.session });
+    });
+  }
+
+  // Broadcast new session events (from insertEvent in any module)
+  eventBus.on('event:created', (event: SessionEvent) => {
+    broadcast({ type: 'event', event });
   });
 
-  monitor.on('session:activity', (data: { session: Session }) => {
-    broadcast({ type: 'session_update', session: data.session });
-  });
+  // Broadcast notifications sent by the bridge
+  if (bridge) {
+    bridge.on('bridge:notification_sent', (data: { sessionId: string; trigger: string; destination: string }) => {
+      broadcast({
+        type: 'notification',
+        sessionId: data.sessionId,
+        trigger: data.trigger,
+        destination: data.destination,
+      });
+    });
+  }
 }
 
 function broadcast(message: WsOutgoingMessage): void {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,5 +1,6 @@
 import { ulid } from 'ulid';
 import { getDb } from './connection.js';
+import { eventBus } from '../shared/event-bus.js';
 import type {
   Session, SessionUpsert, SessionFilters, SessionStatus,
   Run, RunInsert,
@@ -256,8 +257,8 @@ export function getSubAgents(sessionId: string): SubAgent[] {
 
 // --- Events ---
 
-export function insertEvent(data: EventInsert): void {
-  getDb().prepare(`
+export function insertEvent(data: EventInsert): SessionEvent {
+  const result = getDb().prepare(`
     INSERT INTO session_events (session_id, event_type, from_status, to_status, actor, detail)
     VALUES (?, ?, ?, ?, ?, ?)
   `).run(
@@ -268,6 +269,20 @@ export function insertEvent(data: EventInsert): void {
     data.actor ?? 'monitor',
     data.detail ? JSON.stringify(data.detail) : null,
   );
+
+  const event: SessionEvent = {
+    id: Number(result.lastInsertRowid),
+    session_id: data.session_id,
+    event_type: data.event_type,
+    from_status: data.from_status ?? null,
+    to_status: data.to_status ?? null,
+    actor: data.actor ?? 'monitor',
+    detail: data.detail ? JSON.stringify(data.detail) : null,
+    created_at: new Date().toISOString(),
+  };
+
+  eventBus.emit('event:created', event);
+  return event;
 }
 
 export function listEvents(filters: EventFilters = {}): SessionEvent[] {

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ const bridge = new AgentBridge({
 const app = buildServer({
   manager,
   monitor,
+  bridge,
   logger: true,
 });
 

--- a/src/shared/event-bus.ts
+++ b/src/shared/event-bus.ts
@@ -1,0 +1,7 @@
+import { EventEmitter } from 'node:events';
+
+/**
+ * Global event bus for cross-module communication.
+ * Used by insertEvent to broadcast new session events to WebSocket clients.
+ */
+export const eventBus = new EventEmitter();

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -258,6 +258,35 @@ describe('REST API', () => {
       expect(body.needs_attention).toHaveLength(1);
       expect(body.active_sessions).toHaveLength(1);
     });
+
+    it('by_project.ended_today only counts sessions ended today', async () => {
+      const db = getDb();
+
+      // Session ended today — should be counted
+      const s1 = queries.upsertSession({
+        claude_session_id: 'cs-rp1', jsonl_path: '/tmp/rp1.jsonl',
+        status: 'ended', project_name: 'proj-a',
+      });
+
+      // Session ended yesterday — should NOT be counted
+      const s2 = queries.upsertSession({
+        claude_session_id: 'cs-rp2', jsonl_path: '/tmp/rp2.jsonl',
+        status: 'ended', project_name: 'proj-a',
+      });
+      db.prepare("UPDATE sessions SET updated_at = datetime('now', '-1 day') WHERE id = ?").run(s2.id);
+
+      // Active session in same project — should appear in active count
+      queries.upsertSession({
+        claude_session_id: 'cs-rp3', jsonl_path: '/tmp/rp3.jsonl',
+        status: 'active', project_name: 'proj-a',
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/report' });
+      const body = response.json();
+
+      expect(body.by_project['proj-a'].ended_today).toBe(1);
+      expect(body.by_project['proj-a'].active).toBe(1);
+    });
   });
 
   // --- Events ---

--- a/tests/integration/websocket.test.ts
+++ b/tests/integration/websocket.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { buildServer } from '../../src/api/server.js';
 import { initDb, closeDb } from '../../src/db/connection.js';
+import * as queries from '../../src/db/queries.js';
 import { EventEmitter } from 'node:events';
 import WebSocket from 'ws';
 import type { FastifyInstance } from 'fastify';
@@ -12,13 +13,15 @@ describe('WebSocket /ws', () => {
   let app: FastifyInstance;
   let dbPath: string;
   let mockMonitor: EventEmitter;
+  let mockBridge: EventEmitter;
   let port: number;
 
   beforeAll(async () => {
     dbPath = path.join(os.tmpdir(), `sentinel-ws-${Date.now()}.db`);
     initDb(dbPath);
     mockMonitor = new EventEmitter();
-    app = buildServer({ manager: null, monitor: mockMonitor });
+    mockBridge = new EventEmitter();
+    app = buildServer({ manager: null, monitor: mockMonitor, bridge: mockBridge });
     await app.listen({ port: 0 });
     const address = app.server.address();
     port = typeof address === 'object' ? address!.port : 0;
@@ -136,5 +139,62 @@ describe('WebSocket /ws', () => {
     expect(message.sessionId).toBe('ss-disconnect');
 
     ws2.close();
+  });
+
+  it('broadcasts event type when insertEvent is called', async () => {
+    const session = queries.upsertSession({
+      claude_session_id: 'cs-ws-event',
+      jsonl_path: '/tmp/ws-event.jsonl',
+      status: 'active',
+    });
+
+    const ws = new WebSocket(`ws://localhost:${port}/ws`);
+    await new Promise<void>(resolve => ws.on('open', resolve));
+
+    const received = new Promise<any>(resolve => {
+      ws.on('message', (data) => resolve(JSON.parse(data.toString())));
+    });
+
+    queries.insertEvent({
+      session_id: session.id,
+      event_type: 'status_change',
+      from_status: 'active',
+      to_status: 'waiting',
+      actor: 'monitor',
+    });
+
+    const message = await received;
+    expect(message.type).toBe('event');
+    expect(message.event.session_id).toBe(session.id);
+    expect(message.event.event_type).toBe('status_change');
+    expect(message.event.from_status).toBe('active');
+    expect(message.event.to_status).toBe('waiting');
+    expect(message.event).toHaveProperty('id');
+    expect(message.event).toHaveProperty('created_at');
+
+    ws.close();
+  });
+
+  it('broadcasts notification type when bridge sends notification', async () => {
+    const ws = new WebSocket(`ws://localhost:${port}/ws`);
+    await new Promise<void>(resolve => ws.on('open', resolve));
+
+    const received = new Promise<any>(resolve => {
+      ws.on('message', (data) => resolve(JSON.parse(data.toString())));
+    });
+
+    mockBridge.emit('bridge:notification_sent', {
+      sessionId: 'ss-notif-test',
+      trigger: 'waiting',
+      destination: '#jarvis',
+    });
+
+    const message = await received;
+    expect(message.type).toBe('notification');
+    expect(message.sessionId).toBe('ss-notif-test');
+    expect(message.trigger).toBe('waiting');
+    expect(message.destination).toBe('#jarvis');
+
+    ws.close();
   });
 });


### PR DESCRIPTION
## Summary

- **by_project.ended_today** in GET /report now filters by today's date, matching `summary.ended_today` behavior. Previously counted all ended sessions regardless of when they ended.
- **WebSocket** now broadcasts all 4 message types defined in `WsOutgoingMessage`:
  - `session_update` — already wired ✅
  - `status_change` — already wired ✅
  - `event` — **NEW**: broadcasts via shared event bus when `insertEvent` is called from any module (monitor, manager)
  - `notification` — **NEW**: broadcasts when bridge sends a notification, via bridge EventEmitter passed to WebSocket

### Architecture for WebSocket fix

Created `src/shared/event-bus.ts` — a singleton EventEmitter that `insertEvent` emits on after DB insert. This avoids coupling between modules: any code that calls `insertEvent` automatically gets WebSocket broadcast for free. For notifications, the bridge EventEmitter is passed through `ServerConfig` → `registerWebSocket`.

## Test plan

- [ ] `by_project.ended_today only counts sessions ended today` — creates sessions with today/yesterday dates, verifies only today's count
- [ ] `broadcasts event type when insertEvent is called` — calls insertEvent, verifies WebSocket client receives `event` message with full SessionEvent data
- [ ] `broadcasts notification type when bridge sends notification` — emits bridge event, verifies WebSocket client receives `notification` message
- [ ] All 145 tests pass (142 existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)