### PR TITLE
chore(dashboard): systemd deploy on homeserver01 — closes #36

### DIFF
--- a/deploy/sentinel-dashboard.service
+++ b/deploy/sentinel-dashboard.service
@@ -11,6 +11,7 @@ ExecStart=/usr/bin/node build/index.js
 Environment=PORT=3002
 Environment=PUBLIC_API_URL=http://localhost:3100
 # For LAN access: set PUBLIC_API_URL=http://192.168.1.12:3100
+# and set CORS_ORIGINS=http://192.168.1.12:3002 in sentinel.service
 Restart=on-failure
 RestartSec=5
 

--- a/deploy/sentinel-dashboard.service
+++ b/deploy/sentinel-dashboard.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Session Sentinel Dashboard (SvelteKit)
+After=network.target sentinel.service
+Wants=sentinel.service
+
+[Service]
+Type=simple
+User=blasi
+WorkingDirectory=/home/blasi/session-sentinel/dashboard
+ExecStart=/usr/bin/node build/index.js
+Environment=PORT=3002
+Environment=PUBLIC_API_URL=http://localhost:3100
+# For LAN access: set PUBLIC_API_URL=http://192.168.1.12:3100
+Restart=on-failure
+RestartSec=5
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=sentinel-dashboard
+
+# Security
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/home/blasi/session-sentinel/dashboard
+ProtectHome=tmpfs
+BindPaths=/home/blasi
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Adds `deploy/sentinel-dashboard.service` systemd unit to run the SvelteKit dashboard in production
- Configured with `PORT=3002`, `PUBLIC_API_URL=http://localhost:3100`, `After=sentinel.service`
- Matches security hardening of existing `sentinel.service` (NoNewPrivileges, ProtectSystem, ProtectHome)
- Includes LAN access comment per issue review feedback

## Test plan

- [x] `npm run build` in `dashboard/` succeeds (adapter-node, `build/index.js` produced)
- [x] All 171 existing tests pass — no regressions
- [ ] On homeserver01: `sudo systemctl enable --now sentinel-dashboard` starts dashboard on port 3002
- [ ] Dashboard loads data from API at localhost:3100
- [ ] Verify `CORS_ORIGINS` in sentinel.service includes LAN origin if accessed remotely

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)