### PR TITLE
fix(dashboard): state_unsafe_mutation + WebSocket host — closes #41

### DIFF
--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -94,9 +94,12 @@
 
   // Keep last known session to avoid abrupt panel closure when session leaves the list
   let lastSelected = $state(null);
-  let selected = $derived.by(() => {
+  $effect(() => {
     const found = data.sessions?.find(s => s.id === selectedId) ?? null;
     if (found) lastSelected = found;
+  });
+  let selected = $derived.by(() => {
+    const found = data.sessions?.find(s => s.id === selectedId) ?? null;
     return found ?? (selectedId ? lastSelected : null);
   });
 

--- a/deploy/sentinel-dashboard.service
+++ b/deploy/sentinel-dashboard.service
@@ -9,9 +9,8 @@ User=blasi
 WorkingDirectory=/home/blasi/session-sentinel/dashboard
 ExecStart=/usr/bin/node build/index.js
 Environment=PORT=3002
-Environment=PUBLIC_API_URL=http://localhost:3100
-# For LAN access: set PUBLIC_API_URL=http://192.168.1.12:3100
-# and set CORS_ORIGINS=http://192.168.1.12:3002 in sentinel.service
+Environment=PUBLIC_API_URL=http://192.168.1.12:3100
+# CORS_ORIGINS must match in sentinel.service: CORS_ORIGINS=http://192.168.1.12:3002
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Summary

- **Bug 1 — `state_unsafe_mutation`**: `lastSelected` era mutado dentro de `$derived.by()` em `+page.svelte`. Svelte 5 não permite escrever `$state` dentro de um bloco derivado. Movido o tracking para um `$effect` separado; o `$derived.by()` agora só lê `lastSelected`.
- **Bug 2 — WebSocket conecta em `localhost`**: `PUBLIC_API_URL` no arquivo de serviço estava com `localhost:3100`. Corrigido para `192.168.1.12:3100` para que browsers remotos na LAN conectem ao homeserver01 corretamente.

Issue #42 era duplicata do Bug 1 e foi fechada com link para esta.

## Test plan

- [x] Abrir o dashboard em `http://192.168.1.12:3002` de uma máquina diferente do homeserver01
- [x] Clicar em qualquer linha da tabela — SidePanel deve abrir sem erros no console
- [x] Verificar que o WebSocket conecta em `ws://192.168.1.12:3100/ws` (não `localhost`)
- [x] Clicar em outra sessão — painel deve trocar sem crash
- [ ] Clicar na mesma linha para fechar o painel

🤖 Generated with [Claude Code](https://claude.com/claude-code)